### PR TITLE
Introduce `Proxy` struct for configurable HTTP and gRPC transfers

### DIFF
--- a/pkg/url-proxy/grpc_helpers.go
+++ b/pkg/url-proxy/grpc_helpers.go
@@ -24,7 +24,7 @@ func isGRPCScheme(scheme string) bool {
 	return scheme == "grpc" || scheme == "grpcs"
 }
 
-func newByteStreamClientFromURL(ctx context.Context, info *storage.URLInfo) (bytestream.ByteStreamClient, io.Closer, error) {
+func newByteStreamClientFromURL(ctx context.Context, info *storage.URLInfo, extraDialOpts ...grpc.DialOption) (bytestream.ByteStreamClient, io.Closer, error) {
 	if info == nil {
 		return nil, io.NopCloser(strings.NewReader("")), fmt.Errorf("url info is nil")
 	}
@@ -67,6 +67,8 @@ func newByteStreamClientFromURL(ctx context.Context, info *storage.URLInfo) (byt
 			}),
 		)
 	}
+
+	opts = append(opts, extraDialOpts...)
 
 	conn, err := grpc.NewClient(address, opts...)
 	if err != nil {

--- a/pkg/url-proxy/http_test.go
+++ b/pkg/url-proxy/http_test.go
@@ -1,0 +1,106 @@
+package urlproxy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cirruslabs/omni-cache/pkg/storage"
+)
+
+type recordingRoundTripper struct {
+	responseStatus int
+	responseBody   []byte
+
+	called  bool
+	lastReq *http.Request
+	body    []byte
+}
+
+func (rt *recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.called = true
+	rt.lastReq = req
+
+	if req.Body != nil {
+		defer req.Body.Close()
+		body, _ := io.ReadAll(req.Body)
+		rt.body = body
+	}
+
+	status := rt.responseStatus
+	if status == 0 {
+		status = http.StatusOK
+	}
+
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(bytes.NewReader(rt.responseBody)),
+		Header:     http.Header{},
+	}, nil
+}
+
+type failingRoundTripper struct{}
+
+func (failingRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("default client should not be used")
+}
+
+func TestProxyDownloadFromURL_CustomHTTPClient(t *testing.T) {
+	recordingTransport := &recordingRoundTripper{
+		responseBody: []byte("downloaded"),
+	}
+	proxy := NewProxy(WithHTTPClient(&http.Client{Transport: recordingTransport}))
+
+	defaultClient := http.DefaultClient
+	http.DefaultClient = &http.Client{Transport: failingRoundTripper{}}
+	t.Cleanup(func() {
+		http.DefaultClient = defaultClient
+	})
+
+	rec := httptest.NewRecorder()
+	ok := proxy.ProxyDownloadFromURL(context.Background(), rec, &storage.URLInfo{URL: "http://example.com/cache"}, "res")
+	require.True(t, ok)
+
+	require.True(t, recordingTransport.called)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "downloaded", rec.Body.String())
+}
+
+func TestProxyUploadToURL_CustomHTTPClient(t *testing.T) {
+	recordingTransport := &recordingRoundTripper{
+		responseStatus: http.StatusOK,
+	}
+	proxy := NewProxy(WithHTTPClient(&http.Client{Transport: recordingTransport}))
+
+	defaultClient := http.DefaultClient
+	http.DefaultClient = &http.Client{Transport: failingRoundTripper{}}
+	t.Cleanup(func() {
+		http.DefaultClient = defaultClient
+	})
+
+	payload := []byte("upload body")
+	rec := httptest.NewRecorder()
+	ok := proxy.ProxyUploadToURL(context.Background(), rec, &storage.URLInfo{
+		URL: "http://example.com/upload",
+		ExtraHeaders: map[string]string{
+			"X-Test": "value",
+		},
+	}, UploadResource{
+		Body:          bytes.NewReader(payload),
+		ContentLength: int64(len(payload)),
+		ResourceName:  "res",
+	})
+	require.True(t, ok)
+
+	require.True(t, recordingTransport.called)
+	require.Equal(t, payload, recordingTransport.body)
+	require.Equal(t, "value", recordingTransport.lastReq.Header.Get("X-Test"))
+	require.Equal(t, "application/octet-stream", recordingTransport.lastReq.Header.Get("Content-Type"))
+	require.Equal(t, http.StatusCreated, rec.Code)
+}

--- a/pkg/url-proxy/proxy.go
+++ b/pkg/url-proxy/proxy.go
@@ -1,0 +1,41 @@
+package urlproxy
+
+import (
+	"net/http"
+
+	"google.golang.org/grpc"
+)
+
+// Proxy routes download and upload requests through HTTP or gRPC using the provided clients/options.
+type Proxy struct {
+	httpClient      *http.Client
+	grpcDialOptions []grpc.DialOption
+}
+
+type ProxyOption func(*Proxy)
+
+// WithHTTPClient sets the HTTP client used for HTTP transfers. If omitted or nil, http.DefaultClient is used.
+func WithHTTPClient(client *http.Client) ProxyOption {
+	return func(p *Proxy) {
+		p.httpClient = client
+	}
+}
+
+// WithGRPCDialOptions appends custom gRPC DialOptions used when establishing ByteStream connections.
+func WithGRPCDialOptions(opts ...grpc.DialOption) ProxyOption {
+	return func(p *Proxy) {
+		p.grpcDialOptions = append(p.grpcDialOptions, opts...)
+	}
+}
+
+// NewProxy builds a Proxy configured via provided options.
+func NewProxy(opts ...ProxyOption) *Proxy {
+	p := &Proxy{}
+	for _, opt := range opts {
+		opt(p)
+	}
+	if p.httpClient == nil {
+		p.httpClient = http.DefaultClient
+	}
+	return p
+}


### PR DESCRIPTION
- Encapsulated HTTP clients and gRPC dial options within a new `Proxy` struct.
- Refactored `ProxyDownloadFromURL` and `ProxyUploadToURL` to be instance methods.
- Enhanced gRPC and HTTP customizability via `WithHTTPClient` and `WithGRPCDialOptions`.
- Updated tests to leverage the new `Proxy` struct for better encapsulation and consistency.
- Replaced direct `http.DefaultClient` usage with configurable proxies.