### PR TITLE
Fix gRPC proxy writing HTTP 200 before receiving data

### DIFF
--- a/pkg/url-proxy/download.go
+++ b/pkg/url-proxy/download.go
@@ -77,8 +77,6 @@ func (p *Proxy) proxyGRPCDownload(ctx context.Context, w http.ResponseWriter, in
 		return false
 	}
 
-	w.WriteHeader(http.StatusOK)
-
 	var bytesRead int64
 	for {
 		msg, err := stream.Recv()
@@ -103,5 +101,5 @@ func (p *Proxy) proxyGRPCDownload(ctx context.Context, w http.ResponseWriter, in
 	}
 
 	slog.InfoContext(ctx, "proxy cache gRPC download succeeded", "url", info.URL, "bytesProxied", bytesRead)
-	return true
+	return bytesRead > 0
 }


### PR DESCRIPTION
Previously, proxyGRPCDownload wrote HTTP 200 status immediately after starting the gRPC stream, before receiving any data. When stream.Recv() failed (e.g., NotFound), the response was already committed with 200, causing the caller's error status write to be ignored.

This resulted in silent failures: HTTP clients received 200 OK with an empty body, which cirrus-cli interpreted as a cache hit with empty content, leading to skipped cache uploads and broken caching.

Now the status is implicitly written on the first successful Write(), and the function returns false for empty responses, allowing callers to handle errors appropriately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)